### PR TITLE
AudioPlayerManager additional API methods

### DIFF
--- a/Audio.ios.js
+++ b/Audio.ios.js
@@ -5,7 +5,7 @@
  * implementation details for registering callbacks, changing settings, etc.
 */
 
-var React, {NativeModules, NativeAppEventEmitter} = require('react-native');
+var React, {NativeModules, NativeAppEventEmitter, DeviceEventEmitter} = require('react-native');
 
 var AudioPlayerManager = NativeModules.AudioPlayerManager;
 var AudioRecorderManager = NativeModules.AudioRecorderManager;
@@ -20,12 +20,32 @@ var AudioPlayer = {
   pause: function() {
     AudioPlayerManager.pause();
   },
+  unpause: function() {
+    AudioPlayerManager.unpause();
+  },
   stop: function() {
     AudioPlayerManager.stop();
     if (this.subscription) {
       this.subscription.remove();
     }
-  }
+  },
+  setCurrentTime: function(time) {
+    AudioPlayerManager.setCurrentTime(time);
+  },
+  setProgressSubscription: function() {
+    this.progressSubscription = DeviceEventEmitter.addListener('playerProgress',
+      (data) => {
+        if (this.onProgress) {
+          this.onProgress(data);
+        }
+      }
+    );
+  },
+  getDuration: function(callback) {
+    AudioPlayerManager.getDuration((error, duration) => {
+      callback(duration);
+    })
+  },
 };
 
 var AudioRecorder = {

--- a/ios/AudioPlayerManager.m
+++ b/ios/AudioPlayerManager.m
@@ -74,8 +74,6 @@ RCT_EXPORT_METHOD(play:(NSString *)path)
 
   _audioFileURL = [NSURL fileURLWithPath:audioFilePath];
 
-  NSLog([_audioFileURL absoluteString]);
-
   _audioPlayer = [[AVAudioPlayer alloc]
     initWithContentsOfURL:_audioFileURL
     error:&error];
@@ -112,11 +110,31 @@ RCT_EXPORT_METHOD(pause)
   }
 }
 
+RCT_EXPORT_METHOD(unpause)
+{
+  if (!_audioPlayer.playing) {
+    [_audioPlayer play];
+  }
+}
+
 RCT_EXPORT_METHOD(stop)
 {
   if (_audioPlayer.playing) {
     [_audioPlayer stop];
   }
+}
+
+RCT_EXPORT_METHOD(setCurrentTime:(NSTimeInterval) time)
+{
+  if (_audioPlayer.playing) {
+    [_audioPlayer setCurrentTime: time];
+  }
+}
+
+RCT_EXPORT_METHOD(getDuration:(RCTResponseSenderBlock)callback)
+{
+  NSTimeInterval duration = _audioPlayer.duration;
+  callback(@[[NSNull null], [NSNumber numberWithDouble:duration]]);
 }
 
 @end


### PR DESCRIPTION
Added AudioPlayerManager support for unpause, get duration, set progress subscription, and set current time,

These additions allow for the creation of an audio player that can:

- Display the current playback time of the playing audio
- Display the length (duration) of an audio file
- Unpause paused audio
- Navigate/Scrub/Seek to a specific point in an audio file

If PR is accepted, I'll improve the sample project to demonstrate an AudioPlayerManager with these new features and also add to documentation.