### PR TITLE
Added recording options to prepareRecordingAtPath

### DIFF
--- a/Audio.ios.js
+++ b/Audio.ios.js
@@ -66,11 +66,29 @@ var AudioPlayer = {
 };
 
 var AudioRecorder = {
-  prepareRecordingAtPath: function(path) {
-    AudioRecorderManager.prepareRecordingAtPath(path);
+  prepareRecordingAtPath: function(path, options) {
+
+    var recordingOptions = null;
+
+    if (!options) {
+      recordingOptions = {
+        SampleRate: 44100.0,
+        Channels: 2,
+        AudioQuality: 'High'
+      };
+    } else {
+      recordingOptions = options;
+    }
+
+    AudioRecorderManager.prepareRecordingAtPath(
+      path,
+      recordingOptions.SampleRate,
+      recordingOptions.Channels,
+      recordingOptions.AudioQuality
+    );
+
     this.progressSubscription = NativeAppEventEmitter.addListener('recordingProgress',
       (data) => {
-        console.log(data);
         if (this.onProgress) {
           this.onProgress(data);
         }

--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -25,6 +25,9 @@ NSString *const AudioRecorderEventFinished = @"recordingFinished";
   int _progressUpdateInterval;
   NSDate *_prevProgressUpdateTime;
   NSURL *_audioFileURL;
+  NSNumber *_audioQuality;
+  NSNumber *_audioChannels;
+  NSNumber *_audioSampleRate;
   AVAudioSession *_recordSession;
 }
 
@@ -78,7 +81,7 @@ RCT_EXPORT_MODULE();
   return basePath;
 }
 
-RCT_EXPORT_METHOD(prepareRecordingAtPath:(NSString *)path)
+RCT_EXPORT_METHOD(prepareRecordingAtPath:(NSString *)path sampleRate:(float)sampleRate channels:(nonnull NSNumber *)channels quality:(NSString *)quality)
 {
 
   _prevProgressUpdateTime = nil;
@@ -86,13 +89,41 @@ RCT_EXPORT_METHOD(prepareRecordingAtPath:(NSString *)path)
 
   NSString *audioFilePath = [[self applicationDocumentsDirectory] stringByAppendingPathComponent:path];
 
+
   _audioFileURL = [NSURL fileURLWithPath:audioFilePath];
 
+  // Default options
+
+  _audioQuality = [NSNumber numberWithInt:AVAudioQualityHigh];
+  _audioChannels = [NSNumber numberWithInt:2];
+  _audioSampleRate = [NSNumber numberWithFloat:44100.0];
+
+    // Set audio quality from options
+    if (quality != nil) {
+      if ([quality  isEqual: @"Low"]) {
+        _audioQuality =[NSNumber numberWithInt:AVAudioQualityLow];
+      } else if ([quality  isEqual: @"Medium"]) {
+        _audioQuality =[NSNumber numberWithInt:AVAudioQualityMedium];
+      } else if ([quality  isEqual: @"High"]) {
+        _audioQuality =[NSNumber numberWithInt:AVAudioQualityHigh];
+      }
+    }
+
+    // Set channels from options
+    if (channels != nil) {
+      _audioChannels = channels;
+    }
+
+    // Set sample rate from options
+    _audioSampleRate = [NSNumber numberWithFloat:sampleRate];
+
+
+
   NSDictionary *recordSettings = [NSDictionary dictionaryWithObjectsAndKeys:
-          [NSNumber numberWithInt:AVAudioQualityHigh], AVEncoderAudioQualityKey,
+          _audioQuality, AVEncoderAudioQualityKey,
           [NSNumber numberWithInt:16], AVEncoderBitRateKey,
-          [NSNumber numberWithInt: 2], AVNumberOfChannelsKey,
-          [NSNumber numberWithFloat:44100.0], AVSampleRateKey,
+          _audioChannels, AVNumberOfChannelsKey,
+          _audioSampleRate, AVSampleRateKey,
           nil];
 
   NSError *error = nil;


### PR DESCRIPTION
Added the ability to pass options to prepareRecordingAtPath.  These options include Sample Rate, Channels, and Audio Quality.  This is needed because the hard coded defaults aren't necessary for things like recording voice.  The options object is optional, and the default values have been maintained, but are set in Audio.ios.js. 

The options parameter looks like this:

```javascript
recordingOptions = {
        SampleRate: 44100.0,
        Channels: 2,
        AudioQuality: 'High'
     };
```

They are passed from the React Native app like this:

```javascript
    const recordingOptions = {
      SampleRate: 12000.0,
      Channels: 1,
      AudioQuality: 'Low'
    }

    AudioRecorder.prepareRecordingAtPath('/' + this._recordingFile, recordingOptions)
```

The options have no validation, so that should be added at some point.  Calling prepareRecordingAtPath with no options results in the defaults:

```javascript
 {
        SampleRate: 44100.0,
        Channels: 2,
        AudioQuality: 'High'
     };
```