### PR TITLE
A few bug fixes 

### DIFF
--- a/Audio.ios.js
+++ b/Audio.ios.js
@@ -47,7 +47,7 @@ var AudioPlayer = {
   setFinishedSubscription: function() {
     this.progressSubscription = DeviceEventEmitter.addListener('playerFinished',
       (data) => {
-        if (this.onProgress) {
+        if (this.onFinished) {
           this.onFinished(data);
         }
       }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ An audio recording and playback library for react-native.
 
 This release recording and playback of the recording only. PRs are welcome for configuring the audio settings.
 
-NOTE: The target filename must have an extension of '.caf' to record properly.
+NOTE: The target filename must have an extension of '.m4a' to record properly.
+
+NOTE: All files are saved to the app's 'Documents' directory.  When passing a path to play audio, it assumes the file is already in the 'Documents' directory.  This is an example path '/audioFileName.m4a'.
 
 ### Installation
 

--- a/ios/AudioPlayerManager.m
+++ b/ios/AudioPlayerManager.m
@@ -80,12 +80,19 @@ RCT_EXPORT_MODULE();
     }];
 }
 
+- (NSString *) applicationDocumentsDirectory
+{
+  NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+  NSString *basePath = ([paths count] > 0) ? [paths objectAtIndex:0] : nil;
+  return basePath;
+}
+
 RCT_EXPORT_METHOD(play:(NSString *)path)
 {
   NSError *error;
 
-  NSString *resourcePath = [[NSBundle mainBundle] resourcePath];
-  NSString *audioFilePath = [resourcePath stringByAppendingPathComponent:path];
+  NSString *audioFilePath = [[self applicationDocumentsDirectory] stringByAppendingPathComponent:path];
+
 
   _audioFileURL = [NSURL fileURLWithPath:audioFilePath];
 

--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -89,12 +89,11 @@ RCT_EXPORT_METHOD(prepareRecordingAtPath:(NSString *)path)
   _audioFileURL = [NSURL fileURLWithPath:audioFilePath];
 
   NSDictionary *recordSettings = [NSDictionary dictionaryWithObjectsAndKeys:
-          [NSNumber numberWithInt:AVAudioQualityHigh], AVEncoderAudioQualityKey,
-          [NSNumber numberWithInt:16], AVEncoderBitRateKey,
-          [NSNumber numberWithInt: 2], AVNumberOfChannelsKey,
-          [NSNumber numberWithFloat:44100.0], AVSampleRateKey,
+          [NSNumber numberWithInt:AVAudioQualityLow], AVEncoderAudioQualityKey,
+          [NSNumber numberWithInt: kAudioFormatMPEG4AAC], AVFormatIDKey,
+          [NSNumber numberWithInt: 1], AVNumberOfChannelsKey,
+          [NSNumber numberWithFloat:16000.0], AVSampleRateKey,
           nil];
-
   NSError *error = nil;
 
   _recordSession = [AVAudioSession sharedInstance];


### PR DESCRIPTION
I fixed a couple of bugs (see comments) and made it record in m4a format.  You may not want to change your version to record in m4a but the other changes I think are worth looking at.

Here's my commit message:
When playing audio files, it is assumed that they are located in the Documents folder of the app.
Audio files are recorded in m4a format not caf
Fix bug with onFinished callback
Updated readme