### PR TITLE
Fixes a bug and adds a new play function

### DIFF
--- a/Audio.ios.js
+++ b/Audio.ios.js
@@ -14,6 +14,9 @@ var AudioPlayer = {
   play: function(path) {
     AudioPlayerManager.play(path);
   },
+  playWithPath: function(path) {
+    AudioPlayerManager.playWithPath(path);
+  },
   playWithUrl: function(url) {
     AudioPlayerManager.playWithUrl(url);
   },

--- a/Audio.ios.js
+++ b/Audio.ios.js
@@ -47,7 +47,7 @@ var AudioPlayer = {
   setFinishedSubscription: function() {
     this.progressSubscription = DeviceEventEmitter.addListener('playerFinished',
       (data) => {
-        if (this.onProgress) {
+        if (this.onFinished) {
           this.onFinished(data);
         }
       }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ An audio recording and playback library for react-native.
 
 This release recording and playback of the recording only. PRs are welcome for configuring the audio settings.
 
-NOTE: The target filename must have an extension of '.caf' to record properly.
+NOTE: The target filename must have an extension of '.m4a' to record properly.
+
+NOTE: All files are saved to the app's 'Documents' directory.  When passing a path to play audio, it assumes the file is already in the 'Documents' directory.  This is an example path '/audioFileName.m4a'.
 
 ### Installation
 

--- a/ios/AudioPlayerManager.m
+++ b/ios/AudioPlayerManager.m
@@ -80,12 +80,19 @@ RCT_EXPORT_MODULE();
     }];
 }
 
+- (NSString *) applicationDocumentsDirectory
+{
+  NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+  NSString *basePath = ([paths count] > 0) ? [paths objectAtIndex:0] : nil;
+  return basePath;
+}
+
 RCT_EXPORT_METHOD(play:(NSString *)path)
 {
   NSError *error;
 
-  NSString *resourcePath = [[NSBundle mainBundle] resourcePath];
-  NSString *audioFilePath = [resourcePath stringByAppendingPathComponent:path];
+  NSString *audioFilePath = [[self applicationDocumentsDirectory] stringByAppendingPathComponent:path];
+
 
   _audioFileURL = [NSURL fileURLWithPath:audioFilePath];
 

--- a/ios/AudioPlayerManager.m
+++ b/ios/AudioPlayerManager.m
@@ -91,6 +91,30 @@ RCT_EXPORT_METHOD(play:(NSString *)path)
 {
   NSError *error;
 
+  NSString *resourcePath = [[NSBundle mainBundle] resourcePath];
+  NSString *audioFilePath = [resourcePath stringByAppendingPathComponent:path];
+
+  _audioFileURL = [NSURL fileURLWithPath:audioFilePath];
+
+  _audioPlayer = [[AVAudioPlayer alloc]
+    initWithContentsOfURL:_audioFileURL
+    error:&error];
+  _audioPlayer.delegate = self;
+
+  if (error) {
+    [self stopProgressTimer];
+    NSLog(@"audio playback loading error: %@", [error localizedDescription]);
+    // TODO: dispatch error over the bridge
+  } else {
+    [self startProgressTimer];
+    [_audioPlayer play];
+  }
+}
+
+RCT_EXPORT_METHOD(playWithPath:(NSString *)path)
+{
+  NSError *error;
+
   NSString *audioFilePath = [[self applicationDocumentsDirectory] stringByAppendingPathComponent:path];
 
 

--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -89,12 +89,11 @@ RCT_EXPORT_METHOD(prepareRecordingAtPath:(NSString *)path)
   _audioFileURL = [NSURL fileURLWithPath:audioFilePath];
 
   NSDictionary *recordSettings = [NSDictionary dictionaryWithObjectsAndKeys:
-          [NSNumber numberWithInt:AVAudioQualityHigh], AVEncoderAudioQualityKey,
-          [NSNumber numberWithInt:16], AVEncoderBitRateKey,
-          [NSNumber numberWithInt: 2], AVNumberOfChannelsKey,
-          [NSNumber numberWithFloat:44100.0], AVSampleRateKey,
+          [NSNumber numberWithInt:AVAudioQualityLow], AVEncoderAudioQualityKey,
+          [NSNumber numberWithInt: kAudioFormatMPEG4AAC], AVFormatIDKey,
+          [NSNumber numberWithInt: 1], AVNumberOfChannelsKey,
+          [NSNumber numberWithFloat:16000.0], AVSampleRateKey,
           nil];
-
   NSError *error = nil;
 
   _recordSession = [AVAudioSession sharedInstance];


### PR DESCRIPTION
Fixes a bug/typo with onFinish callback on the AudioPlayer
Added a function to play files from the Documents folder (for example that have been recorded).
This code also records the audio in m4a format and you might want to cherry pick that out if you don't want to move over from caf.