### PR TITLE
Added support for Audio Session in playback

### DIFF
--- a/Audio.ios.js
+++ b/Audio.ios.js
@@ -11,11 +11,28 @@ var AudioPlayerManager = NativeModules.AudioPlayerManager;
 var AudioRecorderManager = NativeModules.AudioRecorderManager;
 
 var AudioPlayer = {
-  play: function(path) {
-    AudioPlayerManager.play(path);
+  play: function(path, options) {
+    var playbackOptions = null;
+
+    if (!options) {
+      playbackOptions = {
+        sessionCategory: 'SoloAmbient'
+      };
+    } else {
+      playbackOptions = options;
+    }
+    AudioPlayerManager.play(path, playbackOptions);
   },
-  playWithUrl: function(url) {
-    AudioPlayerManager.playWithUrl(url);
+  playWithUrl: function(url, options) {
+    var playbackOptions = null;
+    if (!options) {
+      playbackOptions = {
+        sessionCategory: 'SoloAmbient'
+      };
+    } else {
+      playbackOptions = options;
+    }
+    AudioPlayerManager.playWithUrl(url, playbackOptions);
   },
   pause: function() {
     AudioPlayerManager.pause();

--- a/ios/AudioPlayerManager.m
+++ b/ios/AudioPlayerManager.m
@@ -80,12 +80,30 @@ RCT_EXPORT_MODULE();
     }];
 }
 
-RCT_EXPORT_METHOD(play:(NSString *)path)
+RCT_EXPORT_METHOD(play:(NSString *)path options:(NSDictionary *)options)
 {
   NSError *error;
 
   NSString *resourcePath = [[NSBundle mainBundle] resourcePath];
   NSString *audioFilePath = [resourcePath stringByAppendingPathComponent:path];
+
+  NSString *sessionCategory = [RCTConvert NSString:options[@"sessionCategory"]];
+
+  if ([sessionCategory isEqualToString:@"Ambient"]) {
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:nil];
+  } else if ([sessionCategory isEqualToString:@"SoloAmbient"]) {
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategorySoloAmbient error:nil];
+  } else if ([sessionCategory isEqualToString:@"Playback"]) {
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+  } else if ([sessionCategory isEqualToString:@"Record"]) {
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryRecord error:nil];
+  } else if ([sessionCategory isEqualToString:@"PlayAndRecord"]) {
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
+  } else if ([sessionCategory isEqualToString:@"AudioProcessing"]) {
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAudioProcessing error:nil];
+  } else if ([sessionCategory isEqualToString:@"MultiRoute"]) {
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryMultiRoute error:nil];
+  }
 
   _audioFileURL = [NSURL fileURLWithPath:audioFilePath];
 
@@ -104,10 +122,27 @@ RCT_EXPORT_METHOD(play:(NSString *)path)
   }
 }
 
-RCT_EXPORT_METHOD(playWithUrl:(NSURL *) url)
+RCT_EXPORT_METHOD(playWithUrl:(NSURL *) url options:(NSDictionary *)options)
 {
   NSError *error;
   NSData* data = [NSData dataWithContentsOfURL: url];
+  NSString *sessionCategory = [RCTConvert NSString:options[@"sessionCategory"]];
+
+  if ([sessionCategory isEqualToString:@"Ambient"]) {
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:nil];
+  } else if ([sessionCategory isEqualToString:@"SoloAmbient"]) {
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategorySoloAmbient error:nil];
+  } else if ([sessionCategory isEqualToString:@"Playback"]) {
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+  } else if ([sessionCategory isEqualToString:@"Record"]) {
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryRecord error:nil];
+  } else if ([sessionCategory isEqualToString:@"PlayAndRecord"]) {
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
+  } else if ([sessionCategory isEqualToString:@"AudioProcessing"]) {
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAudioProcessing error:nil];
+  } else if ([sessionCategory isEqualToString:@"MultiRoute"]) {
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryMultiRoute error:nil];
+  }
 
   _audioPlayer = [[AVAudioPlayer alloc] initWithData:data  error:&error];
   _audioPlayer.delegate = self;


### PR DESCRIPTION
AudioPlayerManager play and playWithUrl accepts options.  This PR supports setting the AudioSessionCategory.  For example:

```javascript
AudioPlayer.playWithUrl(url, { sessionCategory: 'Playback' })
```

Below are the supported categories (info from [iOS Dev Guide])(https://developer.apple.com/library/ios/documentation/Audio/Conceptual/AudioSessionProgrammingGuide/AudioSessionBasics/AudioSessionBasics.html)

| Category  | Native Category | Description |
| ------------ | ---------- | -------------|
| Ambient | AVAudioSessionCategoryAmbient | Playback only. Plays sounds that add polish or interest but are not essential to the app’s use. Using this category, your audio is silenced by the Ring/Silent switch and when the screen locks. |
| SoloAmbient | AVAudioSessionCategorySoloAmbient | (Default) Playback only. Silences audio when the user switches the Ring/Silent switch to the “silent” position and when the screen locks. This category differs from the AVAudioSessionCategoryAmbient category only in that it interrupts other audio. |
| Playback | AVAudioSessionCategoryPlayback | Playback only. Plays audio even with the screen locked and with the Ring/Silent switch set to silent. Use this category for an app whose audio playback is of primary importance. |
| Record | AVAudioSessionCategoryRecord | Record only. Use AVAudioSessionCategoryPlayAndRecord if your app also plays audio. |
| PlayAndRecord | AVAudioSessionCategoryPlayAndRecord | Playback and record. The input and output need not occur simultaneously, but can if needed. Use for audio chat apps. |
| AudioProcessing | AVAudioSessionCategoryAudioProcessing | Offline audio processing only. Performs offline audio processing and no playing or recording. |
| MultiRoute | AVAudioSessionCategoryMultiRoute | Playback and record. Allow simultaneous input and output for different audio streams, for example, USB and headphone output. A DJ app would benefit from using the multiroute category. A DJ often needs to listen to one track of music while another track is playing. Using the multiroute category, a DJ app can play future tracks through the headphones while the current track is played for the dancers. |

Note: If you choose an audio session category that allows audio to keep playing when the screen locks, you must set the UIBackgroundModes audio in your app’s info.plist. See UIBackgroundModes for more information. You should normally not disable the system’s sleep timer via the idleTimerDisabled property. If you do disable the sleep timer, be sure to reset this property to NO when your app does not need to prevent screen locking. The sleep timer ensures that the screen goes dark after a user-specified interval, saving battery power.
