### PR TITLE
Added checkAuthorizationStatus and requestAuthorization promise methods

### DIFF
--- a/Audio.ios.js
+++ b/Audio.ios.js
@@ -119,7 +119,10 @@ var AudioRecorder = {
   stopPlaying: function() {
     AudioRecorderManager.stopPlaying();
   },
-  checkDeviceAuthorizationStatus: AudioRecorderManager.checkDeviceAuthorizationStatus
+  checkAuthorizationStatus: AudioRecorderManager.checkAuthorizationStatus,
+  requestAuthorization: function() {
+    AudioRecorderManager.requestAuthorization();
+  },
 };
 
 module.exports = {AudioPlayer, AudioRecorder};

--- a/Audio.ios.js
+++ b/Audio.ios.js
@@ -120,9 +120,7 @@ var AudioRecorder = {
     AudioRecorderManager.stopPlaying();
   },
   checkAuthorizationStatus: AudioRecorderManager.checkAuthorizationStatus,
-  requestAuthorization: function() {
-    AudioRecorderManager.requestAuthorization();
-  },
+  requestAuthorization: AudioRecorderManager.requestAuthorization,
 };
 
 module.exports = {AudioPlayer, AudioRecorder};

--- a/Audio.ios.js
+++ b/Audio.ios.js
@@ -118,7 +118,8 @@ var AudioRecorder = {
   },
   stopPlaying: function() {
     AudioRecorderManager.stopPlaying();
-  }
+  },
+  checkDeviceAuthorizationStatus: AudioRecorderManager.checkDeviceAuthorizationStatus
 };
 
 module.exports = {AudioPlayer, AudioRecorder};

--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -9,6 +9,7 @@
 #import "AudioRecorderManager.h"
 #import "RCTConvert.h"
 #import "RCTBridge.h"
+#import "RCTUtils.h"
 #import "RCTEventDispatcher.h"
 #import <AVFoundation/AVFoundation.h>
 
@@ -212,6 +213,31 @@ RCT_EXPORT_METHOD(stopPlaying)
 {
   if (_audioPlayer.playing) {
     [_audioPlayer stop];
+  }
+}
+
+RCT_EXPORT_METHOD(checkDeviceAuthorizationStatus:(RCTPromiseResolveBlock)resolve reject:(__unused RCTPromiseRejectBlock)reject) {
+  AVAudioSessionRecordPermission permissionStatus = [[AVAudioSession sharedInstance] recordPermission];
+  switch (permissionStatus) {
+    case AVAudioSessionRecordPermissionUndetermined:{
+      [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
+        if(granted) {
+          resolve(@YES);
+        } else {
+          resolve(@NO);
+        }
+      }];
+    }
+    break;
+    case AVAudioSessionRecordPermissionDenied:
+      resolve(@NO);
+      break;
+    case AVAudioSessionRecordPermissionGranted:
+      resolve(@YES);
+      break;
+    default:
+      reject(RCTErrorUnspecified, nil, RCTErrorWithMessage(@("Error checking device authorization status.")));
+      break;
   }
 }
 

--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -216,29 +216,34 @@ RCT_EXPORT_METHOD(stopPlaying)
   }
 }
 
-RCT_EXPORT_METHOD(checkDeviceAuthorizationStatus:(RCTPromiseResolveBlock)resolve reject:(__unused RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(checkAuthorizationStatus:(RCTPromiseResolveBlock)resolve reject:(__unused RCTPromiseRejectBlock)reject)
+{
   AVAudioSessionRecordPermission permissionStatus = [[AVAudioSession sharedInstance] recordPermission];
   switch (permissionStatus) {
-    case AVAudioSessionRecordPermissionUndetermined:{
-      [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
-        if(granted) {
-          resolve(@YES);
-        } else {
-          resolve(@NO);
-        }
-      }];
-    }
+    case AVAudioSessionRecordPermissionUndetermined:
+      resolve(@("undetermined"));
     break;
     case AVAudioSessionRecordPermissionDenied:
-      resolve(@NO);
+      resolve(@("denied"));
       break;
     case AVAudioSessionRecordPermissionGranted:
-      resolve(@YES);
+      resolve(@("granted"));
       break;
     default:
       reject(RCTErrorUnspecified, nil, RCTErrorWithMessage(@("Error checking device authorization status.")));
       break;
   }
+}
+
+RCT_EXPORT_METHOD(requestAuthorization)
+{
+  [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
+    if(granted) {
+      resolve(@YES);
+    } else {
+      resolve(@NO);
+    }
+  }];
 }
 
 @end


### PR DESCRIPTION
Added checkAuthorizationStatus promise method to check if app is authorized to use the microphone.  Returns a string with "undetermined", "granted" or "denied"

Added a requestAuthorization promise method that requests permission to use the microphone.  It returns true if granted and false if denied.

Here's an example of how to use the code:

        // checkAuthorizationStatus
        AudioRecorder.checkAuthorizationStatus()
        .then((result) => {
            switch(result) {
                case "undetermined":
                    // Recording permission has not been requested
                break;
                case "denied":
                    // Recording permission has been denied.  Explain to user that they
                    // need to go to settings and enable microphone access
                break;
                case "granted":
                    // Recording permission has been granted.
                break;
            }
        })
        .catch((err) => {
            console.error(err.message);
        });

        // requestAuthorization
        AudioRecorder.requestAuthorization()
        .then((granted) => {
            if(granted) {
                // User granted permission to use the microphone
            } else {
                // User did not give permission to use the microphone
            }
        });