### PR TITLE
AudioPlayer numberOfLoops option added.

### DIFF
--- a/Audio.ios.js
+++ b/Audio.ios.js
@@ -13,11 +13,25 @@ var AudioRecorderManager = NativeModules.AudioRecorderManager;
 var AudioPlayer = {
 
   play: function(path, options) {
-    options = options || {sessionCategory: 'SoloAmbient'};
+    if (options) {
+      if (!('sessionCategory' in options))
+        options['sessionCategory'] = 'SoloAmbient';
+      if (!('numberOfLoops' in options))
+        options['numberOfLoops'] = 0;
+    } else {
+      options = {sessionCategory: 'SoloAmbient', numberOfLoops: 0}
+    }
     AudioPlayerManager.play(path, options);
   },
   playWithUrl: function(url, options) {
-    options = options || {sessionCategory: 'SoloAmbient'};
+    if (options) {
+      if (!('sessionCategory' in options))
+        options['sessionCategory'] = 'SoloAmbient';
+      if (!('numberOfLoops' in options))
+        options['numberOfLoops'] = 0;
+    } else {
+      options = {sessionCategory: 'SoloAmbient', numberOfLoops: 0}
+    }
     AudioPlayerManager.playWithUrl(url, options);
   },
   pause: function() {

--- a/ios/AudioPlayerManager.m
+++ b/ios/AudioPlayerManager.m
@@ -88,6 +88,7 @@ RCT_EXPORT_METHOD(play:(NSString *)path options:(NSDictionary *)options)
   NSString *audioFilePath = [resourcePath stringByAppendingPathComponent:path];
   NSString *sessionCategory = [RCTConvert NSString:options[@"sessionCategory"]];
   [self setSessionCategory:sessionCategory];
+  NSNumber *numberOfLoops = [RCTConvert NSNumber:options[@"numberOfLoops"]];
 
   _audioFileURL = [NSURL fileURLWithPath:audioFilePath];
 
@@ -95,6 +96,7 @@ RCT_EXPORT_METHOD(play:(NSString *)path options:(NSDictionary *)options)
     initWithContentsOfURL:_audioFileURL
     error:&error];
   _audioPlayer.delegate = self;
+  _audioPlayer.numberOfLoops = [numberOfLoops integerValue];
 
   if (error) {
     [self stopProgressTimer];
@@ -112,9 +114,12 @@ RCT_EXPORT_METHOD(playWithUrl:(NSURL *) url options:(NSDictionary *)options)
   NSData* data = [NSData dataWithContentsOfURL: url];
   NSString *sessionCategory = [RCTConvert NSString:options[@"sessionCategory"]];
   [self setSessionCategory:sessionCategory];
+  NSNumber *numberOfLoops = [RCTConvert NSNumber:options[@"numberOfLoops"]];
 
   _audioPlayer = [[AVAudioPlayer alloc] initWithData:data  error:&error];
   _audioPlayer.delegate = self;
+  _audioPlayer.numberOfLoops = [numberOfLoops integerValue];
+
   if (error) {
     [self stopProgressTimer];
     NSLog(@"audio playback loading error: %@", [error localizedDescription]);


### PR DESCRIPTION
AudioPlayer play() & playWithUrl() both take 'numberOfLoops' as one of the options.
Integer value of -1 is infinite loop.
Defaults to no loop.

Changed Audio.ios.js to accommodate more than one option.