### PR TITLE
Changed play() and prepareRecordingAtPath() to use absolute paths to audio files

### DIFF
--- a/Audio.ios.js
+++ b/Audio.ios.js
@@ -73,7 +73,7 @@ var AudioRecorder = {
       SampleRate: 44100.0,
       Channels: 2,
       AudioQuality: 'High',
-      AudioEncoding: 'caf'
+      AudioEncoding: 'ima4'
     };
     var recordingOptions = {...defaultOptions, ...options};
 
@@ -122,4 +122,11 @@ var AudioRecorder = {
   requestAuthorization: AudioRecorderManager.requestAuthorization,
 };
 
-module.exports = {AudioPlayer, AudioRecorder};
+var AudioUtils = {
+  MainBundlePath: AudioPlayerManager.MainBundlePath,
+  CachesDirectoryPath: AudioPlayerManager.NSCachesDirectoryPath,
+  DocumentDirectoryPath: AudioPlayerManager.NSDocumentDirectoryPath,
+  LibraryDirectoryPath: AudioPlayerManager.NSLibraryDirectoryPath,
+};
+
+module.exports = {AudioPlayer, AudioRecorder, AudioUtils};

--- a/ios/AudioPlayerManager.m
+++ b/ios/AudioPlayerManager.m
@@ -84,12 +84,10 @@ RCT_EXPORT_METHOD(play:(NSString *)path options:(NSDictionary *)options)
 {
   NSError *error;
 
-  NSString *resourcePath = [[NSBundle mainBundle] resourcePath];
-  NSString *audioFilePath = [resourcePath stringByAppendingPathComponent:path];
   NSString *sessionCategory = [RCTConvert NSString:options[@"sessionCategory"]];
   [self setSessionCategory:sessionCategory];
 
-  _audioFileURL = [NSURL fileURLWithPath:audioFilePath];
+  _audioFileURL = [NSURL fileURLWithPath:path];
 
   _audioPlayer = [[AVAudioPlayer alloc]
     initWithContentsOfURL:_audioFileURL
@@ -226,4 +224,19 @@ RCT_EXPORT_METHOD(getDuration:(RCTResponseSenderBlock)callback)
   callback(@[[NSNull null], [NSNumber numberWithDouble:duration]]);
 }
 
+- (NSString *)getPathForDirectory:(int)directory
+{
+  NSArray *paths = NSSearchPathForDirectoriesInDomains(directory, NSUserDomainMask, YES);
+  return [paths firstObject];
+}
+
+- (NSDictionary *)constantsToExport
+{
+  return @{
+    @"MainBundlePath": [[NSBundle mainBundle] bundlePath],
+    @"NSCachesDirectoryPath": [self getPathForDirectory:NSCachesDirectory],
+    @"NSDocumentDirectoryPath": [self getPathForDirectory:NSDocumentDirectory],
+    @"NSLibraryDirectoryPath": [self getPathForDirectory:NSLibraryDirectory]
+  };
+}
 @end

--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -89,9 +89,7 @@ RCT_EXPORT_METHOD(prepareRecordingAtPath:(NSString *)path sampleRate:(float)samp
   _prevProgressUpdateTime = nil;
   [self stopProgressTimer];
 
-  NSString *audioFilePath = [[self applicationDocumentsDirectory] stringByAppendingPathComponent:path];
-
-  _audioFileURL = [NSURL fileURLWithPath:audioFilePath];
+  _audioFileURL = [NSURL fileURLWithPath:path];
 
   // Default options
   _audioQuality = [NSNumber numberWithInt:AVAudioQualityHigh];


### PR DESCRIPTION
Changed play() and prepareRecordingAtPath() to use absolute paths to audio files.

Added AudioUtils module for creating paths to files.  AudioUtils has constants: MainBundlePath, CachesDirectoryPath, DocumentDirectoryPath, LibraryDirectoryPath.  Since the constants are used in both play and record it seemed cleaner to create AudioUtils.

Fixed typo with encoding code, had "caf" as default AudioEncoding type but should be "ima4", "ima4" is the audio encoding for "caf" files.

Here's an example of how to use the new constants.

       
        var {AudioRecorder, AudioPlayer, AudioUtils} = require('react-native-audio');

        // for recording
        var options = {
            SampleRate: 16000.0,
            Channels: 1,
            AudioQuality: 'Medium',
            AudioEncoding: 'aac',
        };
        var audioPath = AudioUtils.DocumentDirectoryPath + '/filename.m4a';
        AudioRecorder.prepareRecordingAtPath(audioPath, options);

        // for playing
        var audioPath = AudioUtils.DocumentDirectoryPath + '/filename.m4a';
        AudioPlayer.play(audioPath);