### PR TITLE
Fix requestAuthorization bridge signature

### DIFF
--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -257,7 +257,8 @@ RCT_EXPORT_METHOD(checkAuthorizationStatus:(RCTPromiseResolveBlock)resolve rejec
   }
 }
 
-RCT_EXPORT_METHOD(requestAuthorization:(RCTPromiseResolveBlock)resolve)
+RCT_EXPORT_METHOD(requestAuthorization:(RCTPromiseResolveBlock)resolve
+                  rejecter:(__unused RCTPromiseRejectBlock)reject)
 {
   [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
     if(granted) {


### PR DESCRIPTION
I received the error ```Exception 'The RCTPromiseResolveBlock must be the second to last parameter in -[AudioRecorderManager requestAuthorization:(RCTPromiseResolveBlock)resolve]' was thrown while invoking requestAuthorization on target AudioRecorderManager``` while using AudioRecorder.requestAuthorization.

This change fixes that error by correcting the method signature of requestAuthorization to take a promise rejection as well as a resolve.

This should also fix the error @Fatxx was having on #47.