### PR TITLE
Add MeteringEnabled option to emit metering information in progress updates

### DIFF
--- a/Audio.ios.js
+++ b/Audio.ios.js
@@ -87,7 +87,8 @@ var AudioRecorder = {
       SampleRate: 44100.0,
       Channels: 2,
       AudioQuality: 'High',
-      AudioEncoding: 'ima4'
+      AudioEncoding: 'ima4',
+      MeteringEnabled: false
     };
     var recordingOptions = {...defaultOptions, ...options};
 
@@ -96,7 +97,8 @@ var AudioRecorder = {
       recordingOptions.SampleRate,
       recordingOptions.Channels,
       recordingOptions.AudioQuality,
-      recordingOptions.AudioEncoding
+      recordingOptions.AudioEncoding,
+      recordingOptions.MeteringEnabled
     );
 
     if (this.progressSubscription) this.progressSubscription.remove();

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ react-native run-ios
 
 This library supports recording, basic playback and offers progress callbacks for both.
 
-To record in AAC format, at 22050 KHz in low quality mono:
+To record in AAC format, at 22050 KHz in low quality mono with metering enabled:
 
 ```
 import {AudioRecorder, AudioUtils} from 'react-native-audio';
@@ -39,7 +39,8 @@ AudioRecorder.prepareRecordingAtPath(audioPath, {
   SampleRate: 22050,
   Channels: 1,
   AudioQuality: "Low",
-  AudioEncoding: "aac"
+  AudioEncoding: "aac",
+  MeteringEnabled: true
 });
 ```
 


### PR DESCRIPTION
Adds the ability to emit information about metering in the `onProgress` callback.

This is useful for providing feedback in an application about whether a recording is happening or not based on amplitude levels from the mic.

This feature is opt-in because [metering uses computing resources](https://developer.apple.com/library/ios/documentation/AVFoundation/Reference/AVAudioRecorder_ClassReference/#//apple_ref/occ/instp/AVAudioRecorder/meteringEnabled).

It's been a while since I've written Obj-C so let me know if you want me to touch this up or anything!