### PR TITLE
[Android] Remove crashing reset

### DIFF
--- a/android/src/main/java/com/rnim/rn/audio/AudioPlayerManager.java
+++ b/android/src/main/java/com/rnim/rn/audio/AudioPlayerManager.java
@@ -188,7 +188,6 @@ class AudioPlayerManager extends ReactContextBaseJavaModule {
       return;
     }
     playMedia("remote", url, promise);
-    sendEvent("playerFinished", null);
     isPlaying = true;
     isPaused = false;
     return;
@@ -202,6 +201,7 @@ class AudioPlayerManager extends ReactContextBaseJavaModule {
 
     mediaPlayer.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
       public void onCompletion(MediaPlayer mp) {
+        sendEvent("playerFinished", null);
         promise.resolve(path);
         mediaPlayer.stop();
         mediaPlayer.release();

--- a/android/src/main/java/com/rnim/rn/audio/AudioPlayerManager.java
+++ b/android/src/main/java/com/rnim/rn/audio/AudioPlayerManager.java
@@ -215,11 +215,7 @@ class AudioPlayerManager extends ReactContextBaseJavaModule {
   }
 
   private boolean preparePlaybackAtPath(String pathType, String path, Promise promise) {
-    if (mediaPlayer == null) {
-      mediaPlayer = new MediaPlayer();
-    } else {
-      mediaPlayer.reset();
-    }
+    mediaPlayer = new MediaPlayer();
 
     mediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
     try {


### PR DESCRIPTION
When stoping/playing rapidly the app crashed because of the `mediaplayer.reset()` method.

This is because of an old issue: [https://code.google.com/p/android/issues/detail?id=959](https://code.google.com/p/android/issues/detail?id=959)

I am definitely unsure if this is this PR is the right thing to do but it prevents our app from crashing on Android.