### PR TITLE
[Android] Remove crashing reset

### DIFF
--- a/android/src/main/java/com/rnim/rn/audio/AudioPlayerManager.java
+++ b/android/src/main/java/com/rnim/rn/audio/AudioPlayerManager.java
@@ -215,11 +215,7 @@ class AudioPlayerManager extends ReactContextBaseJavaModule {
   }
 
   private boolean preparePlaybackAtPath(String pathType, String path, Promise promise) {
-    if (mediaPlayer == null) {
-      mediaPlayer = new MediaPlayer();
-    } else {
-      mediaPlayer.reset();
-    }
+    mediaPlayer = new MediaPlayer();
 
     mediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
     try {


### PR DESCRIPTION
The reset method was crashing the application on Android. This is due to a 7 years old issue and won't ever be fixed. Instanciating a new mediaplayer seems to fix the issue. See #124.