### PR TITLE
RN .40 compatibility (tweak #import statements)

### DIFF
--- a/ios/AudioRecorderManager.h
+++ b/ios/AudioRecorderManager.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2015 Joshua Sierles. All rights reserved.
 //
 
-#import "RCTBridgeModule.h"
-#import "RCTLog.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTLog.h>
 #import <AVFoundation/AVFoundation.h>
 
 @interface AudioRecorderManager : NSObject <RCTBridgeModule, AVAudioRecorderDelegate>

--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -7,10 +7,10 @@
 //
 
 #import "AudioRecorderManager.h"
-#import "RCTConvert.h"
-#import "RCTBridge.h"
-#import "RCTUtils.h"
-#import "RCTEventDispatcher.h"
+#import <React/RCTConvert.h>
+#import <React/RCTBridge.h>
+#import <React/RCTUtils.h>
+#import <React/RCTEventDispatcher.h>
 #import <AVFoundation/AVFoundation.h>
 
 NSString *const AudioRecorderEventProgress = @"recordingProgress";


### PR DESCRIPTION
Please do take a careful look, I'm not an Obj-C dev. Just following the example of other projects' .39->.40 PRs. Compilation fails in RN .40 w/o these changes.

See #140