### PR TITLE
Update the Android example app so it has permission

### DIFF
--- a/AudioExample/android/app/src/main/AndroidManifest.xml
+++ b/AudioExample/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
 
     <uses-sdk
         android:minSdkVersion="16"


### PR DESCRIPTION
The example app still runs great on iOS, and now it has a hope of running on Android, too.

Unfortunately there seem to be some other issues that are breaking Android besides just the permissions. I'm still looking into it but if you have any ideas, please let me know!

The app becomes slow after pressing "RECORD", never sends any `onProgress` callbacks, then doesn't save the audio after you press "STOP".

This PR is based on https://github.com/jsierles/react-native-audio/pull/148, so that should be merged first.