### PR TITLE
Fix crash on Android when trying to stop recording

### DIFF
--- a/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
+++ b/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
@@ -177,10 +177,18 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
       promise.reject("INVALID_STATE", "Please call startRecording before stopping recording");
       return;
     }
-    recorder.stop();
+
+    try {
+      recorder.stop();
+      recorder.release();
+      recorder = null;
+    }
+    catch (final Exception e) {
+      recorder = null;
+    }
+
     isRecording = false;
-    recorder.release();
-    stopTimer();    
+    stopTimer();
     promise.resolve(currentOutputFile);
     sendEvent("recordingFinished", null);
   }


### PR DESCRIPTION
This is the same as https://github.com/jsierles/react-native-audio/pull/143, but rebased and cleaned up. I kept the original commit author.

This is necessary to help fix https://github.com/jsierles/react-native-audio/pull/147. Unfortunately there still seem to be other problems on Android, documented there.

Stack trace that's now fixed:

```java
01-23 17:58:46.718 1478-13591/com.app E/MediaRecorder: stop failed: -1007
01-23 17:58:46.721 1478-13591/com.app E/unknown:React: Exception in native call
              java.lang.RuntimeException: stop failed.
                  at android.media.MediaRecorder.stop(Native Method)
                  at com.rnim.rn.audio.AudioRecorderManager.stopRecording(AudioRecorderManager.java:180)
                  at java.lang.reflect.Method.invoke(Native Method)
                  at com.facebook.react.bridge.BaseJavaModule$JavaMethod.invoke(BaseJavaModule.java:319)
                  at com.facebook.react.cxxbridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:158)
                  at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
                  at android.os.Handler.handleCallback(Handler.java:739)
                  at android.os.Handler.dispatchMessage(Handler.java:95)
                  at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:31)
                  at android.os.Looper.loop(Looper.java:148)
                  at com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run(MessageQueueThreadImpl.java:196)
                  at java.lang.Thread.run(Thread.java:818)
```
