### PR TITLE
Fix Android callbacks

### DIFF
--- a/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
+++ b/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
@@ -181,9 +181,14 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
     try {
       recorder.stop();
       recorder.release();
-      recorder = null;
     }
-    catch (final Exception e) {
+    catch (final RuntimeException e) {
+      // https://developer.android.com/reference/android/media/MediaRecorder.html#stop()
+      Log.e("RUNTIME_EXCEPTION", "No valid audio data received. You may be using a device that can't record audio.");
+      promise.reject("RUNTIME_EXCEPTION", "No valid audio data received. You may be using a device that can't record audio.");
+      return;
+    }
+    finally {
       recorder = null;
     }
 

--- a/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
+++ b/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
@@ -178,6 +178,9 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
       return;
     }
 
+    stopTimer();
+    isRecording = false;
+
     try {
       recorder.stop();
       recorder.release();
@@ -192,8 +195,6 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
       recorder = null;
     }
 
-    isRecording = false;
-    stopTimer();
     promise.resolve(currentOutputFile);
     sendEvent("recordingFinished", null);
   }
@@ -204,7 +205,7 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
     stopRecording(promise);
   }
 
-    private void startTimer(){
+  private void startTimer(){
     stopTimer();
     timer = new Timer();
     timer.scheduleAtFixedRate(new TimerTask() {

--- a/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
+++ b/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
@@ -31,6 +31,9 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 import java.io.FileInputStream;
 
 class AudioRecorderManager extends ReactContextBaseJavaModule {
+
+  private static final String TAG = "ReactNativeAudio";
+
   private static final String DocumentDirectoryPath = "DocumentDirectoryPath";
   private static final String PicturesDirectoryPath = "PicturesDirectoryPath";
   private static final String MainBundlePath = "MainBundlePath";
@@ -38,6 +41,7 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
   private static final String LibraryDirectoryPath = "LibraryDirectoryPath";
   private static final String MusicDirectoryPath = "MusicDirectoryPath";
   private static final String DownloadsDirectoryPath = "DownloadsDirectoryPath";
+
   private Context context;
   private MediaRecorder recorder;
   private String currentOutputFile;
@@ -80,8 +84,7 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
   @ReactMethod
   public void prepareRecordingAtPath(String recordingPath, ReadableMap recordingSettings, Promise promise) {
     if (isRecording){
-      Log.e("INVALID_STATE", "Please call stopRecording before starting recording");
-      promise.reject("INVALID_STATE", "Please call stopRecording before starting recording");
+      logAndRejectPromise(promise, "INVALID_STATE", "Please call stopRecording before starting recording");
     }
 
     recorder = new MediaRecorder();
@@ -97,7 +100,7 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
       recorder.setOutputFile(recordingPath);
     }
     catch(final Exception e) {
-      promise.reject("COULDNT_CONFIGURE_MEDIA_RECORDER" , "Make sure you've added RECORD_AUDIO permission to your AndroidManifest.xml file "+e.getMessage());
+      logAndRejectPromise(promise, "COULDNT_CONFIGURE_MEDIA_RECORDER" , "Make sure you've added RECORD_AUDIO permission to your AndroidManifest.xml file "+e.getMessage());
       return;
     }
 
@@ -106,7 +109,7 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
       recorder.prepare();
       promise.resolve(currentOutputFile);
     } catch (final Exception e) {
-      promise.reject("COULDNT_PREPARE_RECORDING_AT_PATH "+recordingPath, e.getMessage());
+      logAndRejectPromise(promise, "COULDNT_PREPARE_RECORDING_AT_PATH "+recordingPath, e.getMessage());
     }
 
   }
@@ -155,13 +158,11 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
   @ReactMethod
   public void startRecording(Promise promise){
     if (recorder == null){
-      Log.e("RECORDING_NOT_PREPARED", "Please call prepareRecordingAtPath before starting recording");
-      promise.reject("RECORDING_NOT_PREPARED", "Please call prepareRecordingAtPath before starting recording");
+      logAndRejectPromise(promise, "RECORDING_NOT_PREPARED", "Please call prepareRecordingAtPath before starting recording");
       return;
     }
     if (isRecording){
-      Log.e("INVALID_STATE", "Please call stopRecording before starting recording");
-      promise.reject("INVALID_STATE", "Please call stopRecording before starting recording");
+      logAndRejectPromise(promise, "INVALID_STATE", "Please call stopRecording before starting recording");
       return;
     }
     recorder.start();
@@ -173,8 +174,7 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
   @ReactMethod
   public void stopRecording(Promise promise){
     if (!isRecording){
-      Log.e("INVALID_STATE", "Please call startRecording before stopping recording");
-      promise.reject("INVALID_STATE", "Please call startRecording before stopping recording");
+      logAndRejectPromise(promise, "INVALID_STATE", "Please call startRecording before stopping recording");
       return;
     }
 
@@ -187,8 +187,7 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
     }
     catch (final RuntimeException e) {
       // https://developer.android.com/reference/android/media/MediaRecorder.html#stop()
-      Log.e("RUNTIME_EXCEPTION", "No valid audio data received. You may be using a device that can't record audio.");
-      promise.reject("RUNTIME_EXCEPTION", "No valid audio data received. You may be using a device that can't record audio.");
+      logAndRejectPromise(promise, "RUNTIME_EXCEPTION", "No valid audio data received. You may be using a device that can't record audio.");
       return;
     }
     finally {
@@ -234,5 +233,9 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
             .emit(eventName, params);
   }
 
+  private void logAndRejectPromise(Promise promise, String errorCode, String errorMessage) {
+    Log.e(TAG, errorMessage);
+    promise.reject(errorCode, errorMessage);
+  }
 
 }

--- a/index.js
+++ b/index.js
@@ -13,30 +13,6 @@ var AudioRecorderManager = NativeModules.AudioRecorderManager;
 
 var AudioRecorder = {
   prepareRecordingAtPath: function(path, options) {
-    var defaultOptions = {
-      SampleRate: 44100.0,
-      Channels: 2,
-      AudioQuality: 'High',
-      AudioEncoding: 'ima4',
-      OutputFormat: 'mpeg_4',
-      MeteringEnabled: false,
-      AudioEncodingBitRate: 32000
-    };
-    var recordingOptions = {...defaultOptions, ...options};
-
-    if (Platform.OS === 'ios') {
-      AudioRecorderManager.prepareRecordingAtPath(
-        path,
-        recordingOptions.SampleRate,
-        recordingOptions.Channels,
-        recordingOptions.AudioQuality,
-        recordingOptions.AudioEncoding,
-        recordingOptions.MeteringEnabled
-      );
-    } else {
-      return AudioRecorderManager.prepareRecordingAtPath(path, recordingOptions);
-    }
-
     if (this.progressSubscription) this.progressSubscription.remove();
     this.progressSubscription = NativeAppEventEmitter.addListener('recordingProgress',
       (data) => {
@@ -54,6 +30,31 @@ var AudioRecorder = {
         }
       }
     );
+
+    var defaultOptions = {
+      SampleRate: 44100.0,
+      Channels: 2,
+      AudioQuality: 'High',
+      AudioEncoding: 'ima4',
+      OutputFormat: 'mpeg_4',
+      MeteringEnabled: false,
+      AudioEncodingBitRate: 32000
+    };
+
+    var recordingOptions = {...defaultOptions, ...options};
+
+    if (Platform.OS === 'ios') {
+      AudioRecorderManager.prepareRecordingAtPath(
+        path,
+        recordingOptions.SampleRate,
+        recordingOptions.Channels,
+        recordingOptions.AudioQuality,
+        recordingOptions.AudioEncoding,
+        recordingOptions.MeteringEnabled
+      );
+    } else {
+      return AudioRecorderManager.prepareRecordingAtPath(path, recordingOptions);
+    }
   },
   startRecording: function() {
     return AudioRecorderManager.startRecording();

--- a/index.js
+++ b/index.js
@@ -67,6 +67,10 @@ var AudioRecorder = {
   },
   checkAuthorizationStatus: AudioRecorderManager.checkAuthorizationStatus,
   requestAuthorization: AudioRecorderManager.requestAuthorization,
+  removeListeners: function() {
+    if (this.progressSubscription) this.progressSubscription.remove();
+    if (this.finishedSubscription) this.finishedSubscription.remove();
+  },
 };
 
 let AudioUtils = {};


### PR DESCRIPTION
This resolves #149 and resolves #111, though the latter was originally reporting issues with audio playback which was recently removed anyway.

It does a few things:

1. Subscribes to callbacks for `onProgress` and `onFinished` on Android
    - Previously the method returned before these could be subscribed
2. Adds a new method (`removeListeners`) to unsubscribe if desired
3. Prints better error messages on Android when [nothing is recorded](https://github.com/jsierles/react-native-audio/issues/149), e.g. on an emulator
4. Stops the timer before trying to stop the recorder
    - Previously the exception would be thrown and prevent the timer from being stopped
5. Updates the example app to finally work fully on Android :robot:
6. Log Java errors more conventionally, using a `TAG`

Thanks to @Slooowpoke for originally pointing me in the right direction on this!

---

Note: I think most would agree that the current promise handling in the example app is pretty ugly. This is necessary because Android uses promises for callbacks and iOS uses the `onFinished` callback. They should probably be made more consistent -- I think it would be great if they both used promises consistently, but this is a change for another day.