### PR TITLE
Add another timeout to work around an RN-sound issue

### DIFF
--- a/AudioExample/AudioExample.js
+++ b/AudioExample/AudioExample.js
@@ -124,26 +124,30 @@ class AudioExample extends Component {
       }
     }
 
-    _play() {
+    async _play() {
       if (this.state.recording) {
-        this._stop();
+        await this._stop();
       }
 
-      var sound = new Sound(this.state.audioPath, '', (error) => {
-        if (error) {
-          console.log('failed to load the sound', error);
-        }
-      });
-
+      // These timeouts are a hacky workaround for some issues with react-native-sound.
+      // See https://github.com/zmxv/react-native-sound/issues/89.
       setTimeout(() => {
-        sound.play((success) => {
-          if (success) {
-             console.log('successfully finished playing');
-           } else {
-             console.log('playback failed due to audio decoding errors');
-           }
+        var sound = new Sound(this.state.audioPath, '', (error) => {
+          if (error) {
+            console.log('failed to load the sound', error);
+          }
         });
-      }, 500)
+
+        setTimeout(() => {
+          sound.play((success) => {
+            if (success) {
+              console.log('successfully finished playing');
+            } else {
+              console.log('playback failed due to audio decoding errors');
+            }
+          });
+        }, 100);
+      }, 100);
     }
 
     async _record() {


### PR DESCRIPTION
Resolves #153 for the example app. Seems to be an issue with `react-native-sound` described [here](https://github.com/zmxv/react-native-sound/issues/89).

It uses async/await to make sure `_stop` has been called, but that wasn't the fix. The real change here is adding another timeout before trying to load the audio file. I also decreased the delay from 500 down to 100 ms, as that was more than sufficient.

Tested and verified on iOS simulator. @dturton or @dannyyaou can you verify this fixes the issue for you too?