### PR TITLE
AVAudioPlayer fails after recording on ios 10

### DIFF
--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -194,7 +194,7 @@ RCT_EXPORT_METHOD(startRecording)
 RCT_EXPORT_METHOD(stopRecording)
 {
   [_audioRecorder stop];
-  [_recordSession setActive:NO error:nil];
+  [_recordSession setCategory:AVAudioSessionCategoryPlayback error:nil];
   _prevProgressUpdateTime = nil;
 }
 


### PR DESCRIPTION
Fix for AVAudioPlayer failing playing audio after recording on ios10.
This PR resolves #173