### PR TITLE
Create react-native-audio.podspec

### DIFF
--- a/react-native-audio.podspec
+++ b/react-native-audio.podspec
@@ -1,0 +1,22 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'react-native-audio'
+  s.version        = package['version']
+  s.summary        = package['description']
+  s.description    = package['description']
+  s.license        = package['license']
+  s.author         = package['author']
+  s.homepage       = package['homepage']
+  s.source         = { :git => 'https://github.com/jsierles/react-native-audio', :tag => s.version }
+
+  s.requires_arc   = true
+  s.platform       = :ios, '8.0'
+
+  s.preserve_paths = 'LICENSE', 'README.md', 'package.json', 'index.js'
+  s.source_files   = 'ios/*.{h,m}'
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
allow module to be imported as a cocoa pod in iOS

Add this to your Podfile:
`pod 'react-native-audio', path: '../node_modules/react-native-audio'`

and run `pod install` to install. Restart xcode and your ready to use it.