### PR TITLE
[Make compatible with v0.47.1 of react-native] Remove redundant #createJSModules methods

### DIFF
--- a/android/src/main/java/com/rnim/rn/audio/ReactNativeAudioPackage.java
+++ b/android/src/main/java/com/rnim/rn/audio/ReactNativeAudioPackage.java
@@ -26,18 +26,6 @@ public class ReactNativeAudioPackage implements ReactPackage {
     }
 
     /**
-     * @return list of JS modules to register with the newly created catalyst instance.
-     * <p/>
-     * IMPORTANT: Note that only modules that needs to be accessible from the native code should be
-     * listed here. Also listing a native module here doesn't imply that the JS implementation of it
-     * will be automatically included in the JS bundle.
-     */
-    @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    /**
      * @param reactContext
      * @return a list of view managers that should be registered with {UIManagerModule}
      */


### PR DESCRIPTION
Build fails if the #createJSModules method is implemented as has been removed upstream.

Didn't find any other blockers.