### PR TITLE
Handle Android RN 0.47 breaking change

### DIFF
--- a/android/src/main/java/com/rnim/rn/audio/ReactNativeAudioPackage.java
+++ b/android/src/main/java/com/rnim/rn/audio/ReactNativeAudioPackage.java
@@ -25,14 +25,7 @@ public class ReactNativeAudioPackage implements ReactPackage {
         return modules;
     }
 
-    /**
-     * @return list of JS modules to register with the newly created catalyst instance.
-     * <p/>
-     * IMPORTANT: Note that only modules that needs to be accessible from the native code should be
-     * listed here. Also listing a native module here doesn't imply that the JS implementation of it
-     * will be automatically included in the JS bundle.
-     */
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Fixes  #198 and makes react-native-audio work with React Native 0.47.