### PR TITLE
removed deprecated Override

### DIFF
--- a/android/src/main/java/com/rnim/rn/audio/ReactNativeAudioPackage.java
+++ b/android/src/main/java/com/rnim/rn/audio/ReactNativeAudioPackage.java
@@ -32,7 +32,6 @@ public class ReactNativeAudioPackage implements ReactPackage {
      * listed here. Also listing a native module here doesn't imply that the JS implementation of it
      * will be automatically included in the JS bundle.
      */
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Removed the Override annotation from a deprecated method.
Without this the library does not compiled for Android.