### PR TITLE
Adding pause/resume recording for the versions of Android that support it

### DIFF
--- a/AudioExample/AudioExample.js
+++ b/AudioExample/AudioExample.js
@@ -18,6 +18,7 @@ class AudioExample extends Component {
     state = {
       currentTime: 0.0,
       recording: false,
+      paused: false,
       stoppedRecording: false,
       finished: false,
       audioPath: AudioUtils.DocumentDirectoryPath + '/test.aac',
@@ -89,16 +90,15 @@ class AudioExample extends Component {
         console.warn('Can\'t pause, not recording!');
         return;
       }
-
-      this.setState({stoppedRecording: true, recording: false});
-
+    
       try {
         const filePath = await AudioRecorder.pauseRecording();
+        this.setState({paused: !this.state.paused});
 
         // Pause is currently equivalent to stop on Android.
-        if (Platform.OS === 'android') {
-          this._finishRecording(true, filePath);
-        }
+        // if (Platform.OS === 'android') {
+        //   this._finishRecording(true, filePath);
+        // }
       } catch (error) {
         console.error(error);
       }

--- a/AudioExample/AudioExample.js
+++ b/AudioExample/AudioExample.js
@@ -85,6 +85,18 @@ class AudioExample extends Component {
       );
     }
 
+    _renderPauseButton(onPress, active) {
+      var style = (active) ? styles.activeButtonText : styles.buttonText;
+      var title = this.state.paused ? "RESUME" : "PAUSE";
+      return (
+        <TouchableHighlight style={styles.button} onPress={onPress}>
+          <Text style={style}>
+            {title}
+          </Text>
+        </TouchableHighlight>
+      );
+    }
+
     async _pause() {
       if (!this.state.recording) {
         console.warn('Can\'t pause, not recording!');
@@ -94,11 +106,6 @@ class AudioExample extends Component {
       try {
         const filePath = await AudioRecorder.pauseRecording();
         this.setState({paused: !this.state.paused});
-
-        // Pause is currently equivalent to stop on Android.
-        // if (Platform.OS === 'android') {
-        //   this._finishRecording(true, filePath);
-        // }
       } catch (error) {
         console.error(error);
       }
@@ -110,7 +117,7 @@ class AudioExample extends Component {
         return;
       }
 
-      this.setState({stoppedRecording: true, recording: false});
+      this.setState({stoppedRecording: true, recording: false, paused: false});
 
       try {
         const filePath = await AudioRecorder.stopRecording();
@@ -165,7 +172,7 @@ class AudioExample extends Component {
         this.prepareRecordingPath(this.state.audioPath);
       }
 
-      this.setState({recording: true});
+      this.setState({recording: true, paused: false});
 
       try {
         const filePath = await AudioRecorder.startRecording();
@@ -187,7 +194,8 @@ class AudioExample extends Component {
             {this._renderButton("RECORD", () => {this._record()}, this.state.recording )}
             {this._renderButton("PLAY", () => {this._play()} )}
             {this._renderButton("STOP", () => {this._stop()} )}
-            {this._renderButton("PAUSE", () => {this._pause()} )}
+            {/* {this._renderButton("PAUSE", () => {this._pause()} )} */}
+            {this._renderPauseButton(() => {this._pause()})}
             <Text style={styles.progressText}>{this.state.currentTime}s</Text>
           </View>
         </View>

--- a/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
+++ b/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
@@ -36,48 +36,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.IllegalAccessException;
 import java.lang.NoSuchMethodException;
 
-class StopWatch {
-  private long start;
-  private float elapsedTime = 0;
-  private boolean paused = true;
-
-  public StopWatch() {
-  }
-
-  public void start() {
-      start = System.currentTimeMillis();
-      paused = false;
-  }
-
-  public float stop() {
-      if (!paused) {
-          long now = System.currentTimeMillis();
-          elapsedTime += (now - start) / 1000f;
-          paused = true;
-      }
-
-      return elapsedTime;
-  }
-
-  public void reset() {
-      start = 0;
-      elapsedTime = 0;
-      paused = true;
-  }
-
-  public float getTimeSeconds() {
-    float seconds;
-    
-    if (paused) {
-      seconds = elapsedTime;
-    } else {
-      long now = System.currentTimeMillis();
-      seconds = elapsedTime + (now - start) / 1000f;
-    }
-      return seconds;
-  }
-}
-
 class AudioRecorderManager extends ReactContextBaseJavaModule {
 
   private static final String TAG = "ReactNativeAudio";

--- a/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
+++ b/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
@@ -20,6 +20,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Environment;
 import android.media.MediaRecorder;
 import android.media.AudioManager;
@@ -29,6 +30,53 @@ import android.util.Log;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 import java.io.FileInputStream;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.IllegalAccessException;
+import java.lang.NoSuchMethodException;
+
+class StopWatch {
+  private long start;
+  private float elapsedTime = 0;
+  private boolean paused = true;
+
+  public StopWatch() {
+  }
+
+  public void start() {
+      start = System.currentTimeMillis();
+      paused = false;
+  }
+
+  public float stop() {
+      if (!paused) {
+          long now = System.currentTimeMillis();
+          elapsedTime += (now - start) / 1000f;
+          paused = true;
+      }
+
+      return elapsedTime;
+  }
+
+  public void reset() {
+      start = 0;
+      elapsedTime = 0;
+      paused = true;
+  }
+
+  public float getTimeSeconds() {
+    float seconds;
+    
+    if (paused) {
+      seconds = elapsedTime;
+    } else {
+      long now = System.currentTimeMillis();
+      seconds = elapsedTime + (now - start) / 1000f;
+    }
+      return seconds;
+  }
+}
 
 class AudioRecorderManager extends ReactContextBaseJavaModule {
 
@@ -46,13 +94,15 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
   private MediaRecorder recorder;
   private String currentOutputFile;
   private boolean isRecording = false;
+  private boolean isPaused = false;
   private Timer timer;
-  private int recorderSecondsElapsed;
+  private StopWatch stopWatch;
 
 
   public AudioRecorderManager(ReactApplicationContext reactContext) {
     super(reactContext);
     this.context = reactContext;
+    stopWatch = new StopWatch();
   }
 
   @Override
@@ -166,7 +216,11 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
       return;
     }
     recorder.start();
+    
+    stopWatch.reset();
+    stopWatch.start();
     isRecording = true;
+    isPaused = false;
     startTimer();
     promise.resolve(currentOutputFile);
   }
@@ -180,10 +234,12 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
 
     stopTimer();
     isRecording = false;
+    isPaused = false;
 
     try {
       recorder.stop();
       recorder.release();
+      stopWatch.stop();
     }
     catch (final RuntimeException e) {
       // https://developer.android.com/reference/android/media/MediaRecorder.html#stop()
@@ -198,28 +254,61 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
     sendEvent("recordingFinished", null);
   }
 
+  private void togglePause(Promise promise) {      
+    if (!isRecording){
+      logAndRejectPromise(promise, "INVALID_STATE", "Please call startRecording before pausing recording");
+      return;
+    }
+
+    try {
+      if (!isPaused) {
+        Method pauseMethod = MediaRecorder.class.getMethod("pause");
+        pauseMethod.invoke(recorder);
+        stopWatch.stop();
+      } else {
+        Method resumeMethod = MediaRecorder.class.getMethod("resume");
+        resumeMethod.invoke(recorder);
+        stopWatch.start();
+      }
+
+      isPaused = !isPaused;
+      promise.resolve(currentOutputFile);
+    }
+    catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+      e.printStackTrace();
+      logAndRejectPromise(promise, "RUNTIME_EXCEPTION", "Method not available on this version of Android.");
+      return;
+    }
+    catch (final RuntimeException e) {
+      logAndRejectPromise(promise, "RUNTIME_EXCEPTION", "No valid audio data received. You may be using a device that can't record audio.");
+      return;
+    }
+  }
+
   @ReactMethod
   public void pauseRecording(Promise promise){
-    // Added this function to have the same api for android and iOS, stops recording now
-    stopRecording(promise);
+    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
+      togglePause(promise);
+    } else {
+      stopRecording(promise);
+    }
   }
 
   private void startTimer(){
-    stopTimer();
     timer = new Timer();
     timer.scheduleAtFixedRate(new TimerTask() {
       @Override
       public void run() {
-        WritableMap body = Arguments.createMap();
-        body.putInt("currentTime", recorderSecondsElapsed);
-        sendEvent("recordingProgress", body);
-        recorderSecondsElapsed++;
+        if (!isPaused) {
+          WritableMap body = Arguments.createMap();
+          body.putDouble("currentTime", stopWatch.getTimeSeconds());
+          sendEvent("recordingProgress", body);
+        }
       }
     }, 0, 1000);
   }
 
   private void stopTimer(){
-    recorderSecondsElapsed = 0;
     if (timer != null) {
       timer.cancel();
       timer.purge();
@@ -237,5 +326,4 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
     Log.e(TAG, errorMessage);
     promise.reject(errorCode, errorMessage);
   }
-
 }

--- a/android/src/main/java/com/rnim/rn/audio/StopWatch.java
+++ b/android/src/main/java/com/rnim/rn/audio/StopWatch.java
@@ -1,0 +1,46 @@
+package com.rnim.rn.audio;
+
+import java.lang.System;
+import java.lang.Thread;
+
+public class StopWatch {
+    private long start;
+    private float elapsedTime = 0;
+    private boolean paused = true;
+  
+    public StopWatch() {
+    }
+  
+    public void start() {
+        start = System.currentTimeMillis();
+        paused = false;
+    }
+  
+    public float stop() {
+        if (!paused) {
+            long now = System.currentTimeMillis();
+            elapsedTime += (now - start) / 1000f;
+            paused = true;
+        }
+  
+        return elapsedTime;
+    }
+  
+    public void reset() {
+        start = 0;
+        elapsedTime = 0;
+        paused = true;
+    }
+  
+    public float getTimeSeconds() {
+      float seconds;
+      
+      if (paused) {
+        seconds = elapsedTime;
+      } else {
+        long now = System.currentTimeMillis();
+        seconds = elapsedTime + (now - start) / 1000f;
+      }
+        return seconds;
+    }
+  }


### PR DESCRIPTION
**Problem**
`react-native-audio` currently does not implement pausing/resuming  recordings. This is due to the fact that [Android MediaRecording](https://developer.android.com/reference/android/media/MediaRecorder.html) API Level 23 (Marshmallow) does not support pause. However, API Levels 24 and above (Nougat) do include pausing and resuming APIs. If  `react-native-audio` is being used in versions of Android with API Levels 24 and above, it should be able to pause and resume a recordings.

**Proposed Solution**
The strategy is to check at runtime if the available API supports pause/resume recordings. If so, use Java Reflection to inspect the `MediaRecorder` class, get a reference to its `pause` and `resume` methods, and use them. In the case that the available API does not support pause, fall back to stoping the recording instead. 

This solution does not require to change the Android minimum version required. Additionally, it updates the mechanism for measuring the recording time so that it accurately supports pause.

I have done some basic testing, and the implementation seems to work as expected. Feel free to comment / provide feedback.