### PR TITLE
Feature base64 audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Encodings supported on Android: `aac, aac_eld, amr_nb, amr_wb, he_aac, vorbis`
 
 The `MeteringEnabled` boolean to enable audio metering.
 
+The `IncludeBase64` boolean to include the recording `base64` encoded on the `AudioRecorder.onFinished` event object. Please use it with care, since its usage can result in huge memory usage. Furthermore you could sacrifice performance, because a huge base64 encoded string has to be transferred over the bridge.
+If you want to upload the audio, it might be best to do it on the native thread.
+
 #### Android-only fields
 
 AudioEncodingBitRate: int

--- a/README.md
+++ b/README.md
@@ -109,10 +109,11 @@ Encodings supported on Android: `aac, aac_eld, amr_nb, amr_wb, he_aac, vorbis`
 
 #### iOS-only fields
 
-The `MeteringEnabled` boolean to enable audio metering.
+Use `MeteringEnabled` boolean to enable audio metering.
 
-The `IncludeBase64` boolean to include the recording `base64` encoded on the `AudioRecorder.onFinished` event object. Please use it with care, since its usage can result in huge memory usage. Furthermore you could sacrifice performance, because a huge base64 encoded string has to be transferred over the bridge.
-If you want to upload the audio, it might be best to do it on the native thread.
+Use the `IncludeBase64` boolean to include the `base64` encoded recording on the `AudioRecorder.onFinished` event object. Please use it with care: passing large amounts of data over the bridge, from native to Javascript, can use lots of memory and cause slow performance.
+
+If you want to upload the audio, it might be best to do it on the native thread with a package like [React Native Fetch Blob](https://github.com/joltup/react-native-fetch-blob).
 
 #### Android-only fields
 

--- a/index.js
+++ b/index.js
@@ -39,7 +39,8 @@ var AudioRecorder = {
       OutputFormat: 'mpeg_4',
       MeteringEnabled: false,
       MeasurementMode: false,
-      AudioEncodingBitRate: 32000
+      AudioEncodingBitRate: 32000,
+      IncludeBase64: false
     };
 
     var recordingOptions = {...defaultOptions, ...options};
@@ -52,7 +53,8 @@ var AudioRecorder = {
         recordingOptions.AudioQuality,
         recordingOptions.AudioEncoding,
         recordingOptions.MeteringEnabled,
-        recordingOptions.MeasurementMode
+        recordingOptions.MeasurementMode,
+        recordingOptions.IncludeBase64
       );
     } else {
       return AudioRecorderManager.prepareRecordingAtPath(path, recordingOptions);

--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -76,7 +76,11 @@ RCT_EXPORT_MODULE();
 }
 
 - (void)audioRecorderDidFinishRecording:(AVAudioRecorder *)recorder successfully:(BOOL)flag {
+  NSData *data = [NSData dataWithContentsOfFile:_audioFileURL];
+  NSString *base64 = [data base64EncodedStringWithOptions:0];
   [self.bridge.eventDispatcher sendAppEventWithName:AudioRecorderEventFinished body:@{
+      @"base64":base64,
+      @"duration":@(_currentTime),
       @"status": flag ? @"OK" : @"ERROR",
       @"audioFileURL": [_audioFileURL absoluteString]
     }];

--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -32,6 +32,7 @@ NSString *const AudioRecorderEventFinished = @"recordingFinished";
   AVAudioSession *_recordSession;
   BOOL _meteringEnabled;
   BOOL _measurementMode;
+  BOOL _includeBase64;
 }
 
 @synthesize bridge = _bridge;
@@ -76,8 +77,12 @@ RCT_EXPORT_MODULE();
 }
 
 - (void)audioRecorderDidFinishRecording:(AVAudioRecorder *)recorder successfully:(BOOL)flag {
-  NSData *data = [NSData dataWithContentsOfFile:_audioFileURL];
-  NSString *base64 = [data base64EncodedStringWithOptions:0];
+  NString *base64 = nil;
+  if (_includeBase64) {
+    NSData *data = [NSData dataWithContentsOfFile:_audioFileURL];
+    base64 = [data base64EncodedStringWithOptions:0];
+  }
+
   [self.bridge.eventDispatcher sendAppEventWithName:AudioRecorderEventFinished body:@{
       @"base64":base64,
       @"duration":@(_currentTime),
@@ -93,7 +98,7 @@ RCT_EXPORT_MODULE();
   return basePath;
 }
 
-RCT_EXPORT_METHOD(prepareRecordingAtPath:(NSString *)path sampleRate:(float)sampleRate channels:(nonnull NSNumber *)channels quality:(NSString *)quality encoding:(NSString *)encoding meteringEnabled:(BOOL)meteringEnabled measurementMode:(BOOL)measurementMode)
+RCT_EXPORT_METHOD(prepareRecordingAtPath:(NSString *)path sampleRate:(float)sampleRate channels:(nonnull NSNumber *)channels quality:(NSString *)quality encoding:(NSString *)encoding meteringEnabled:(BOOL)meteringEnabled measurementMode:(BOOL)measurementMode includeBase64:(BOOL)includeBase64)
 {
   _prevProgressUpdateTime = nil;
   [self stopProgressTimer];
@@ -106,6 +111,7 @@ RCT_EXPORT_METHOD(prepareRecordingAtPath:(NSString *)path sampleRate:(float)samp
   _audioChannels = [NSNumber numberWithInt:2];
   _audioSampleRate = [NSNumber numberWithFloat:44100.0];
   _meteringEnabled = NO;
+  _includeBase64 = NO;
 
   // Set audio quality from options
   if (quality != nil) {
@@ -168,6 +174,10 @@ RCT_EXPORT_METHOD(prepareRecordingAtPath:(NSString *)path sampleRate:(float)samp
   // Measurement mode to disable mic auto gain and high pass filters
   if (measurementMode != NO) {
     _measurementMode = measurementMode;
+  }
+
+  if (includeBase64) {
+    _includeBase64 = includeBase64;
   }
 
   NSError *error = nil;


### PR DESCRIPTION
Based on #129 

Adds a new boolean flag (`IncludeBase64`) for including the `base64` result on the event object of `AudioRecorder.onFinished` (iOS only). 