### PR TITLE
Update AudioRecorderManager.m

### DIFF
--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -77,7 +77,7 @@ RCT_EXPORT_MODULE();
 }
 
 - (void)audioRecorderDidFinishRecording:(AVAudioRecorder *)recorder successfully:(BOOL)flag {
-  NString *base64 = nil;
+  NSString *base64 = nil;
   if (_includeBase64) {
     NSData *data = [NSData dataWithContentsOfFile:_audioFileURL];
     base64 = [data base64EncodedStringWithOptions:0];


### PR DESCRIPTION
At line 80, `NSString` is written `NString`. A simple typo error.