### PR TITLE
Update AudioRecordermanager.m

### DIFF
--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -77,7 +77,7 @@ RCT_EXPORT_MODULE();
 }
 
 - (void)audioRecorderDidFinishRecording:(AVAudioRecorder *)recorder successfully:(BOOL)flag {
-  NSString *base64 = nil;
+  NSString *base64 = @"";
   if (_includeBase64) {
     NSData *data = [NSData dataWithContentsOfFile:_audioFileURL];
     base64 = [data base64EncodedStringWithOptions:0];


### PR DESCRIPTION
If `NSString *base64 = nil` and `IncludeBase64` is false, Objective-C raise `attempt to insert nil object from objects[0]` error.