### PR TITLE
Resume the music/audio player once recorder has stopped recording

### DIFF
--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -91,6 +91,17 @@ RCT_EXPORT_MODULE();
       @"status": flag ? @"OK" : @"ERROR",
       @"audioFileURL": [_audioFileURL absoluteString]
     }];
+    
+    // This will resume the music/audio file that was playing before the recording started
+    // Without this piece of code, the music/audio will just be stopped
+    NSError *error;
+    [[AVAudioSession sharedInstance] setActive:NO
+                                   withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
+                                         error:&error];
+    if (error) {
+        // TODO: dispatch error over the bridge
+        NSLog(@"error: %@", [error localizedDescription]);
+    }
 }
 
 - (NSString *) applicationDocumentsDirectory


### PR DESCRIPTION
On iOS when `AVAudioRecorder` start recording, it stops all background audio/music already playing (for instance if you listen a music on Spotify or iTunes).

A common behavior for apps is to resume the audio/music player once the recorder did finish recording.

In order to fix this issue I added 
```
[[AVAudioSession sharedInstance] 
    setActive:NO
    withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
    error:&error];
```
into the `AVAudioSession` delegate callback `audioRecorderDidFinishRecording`.

This fix has been tested and works perfectly in my own project.

Please let me know if you have any feedbacks @jsierles @maxhawkins @neilsarkar @lefnire @tommoor 