### PR TITLE
fix: import PermissionsAndroid is missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ import ReactNative, {
   NativeModules,
   NativeAppEventEmitter,
   DeviceEventEmitter,
+  PermissionsAndroid,
   Platform
 } from "react-native";
 


### PR DESCRIPTION
`AudioRecorder.requestAuthorization()` is crash on Android.
The cause is imported Permissions Android is missing.
Fix it. ✈️ 