### PR TITLE
Use sdk, buildTools and support lib versions from root project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,17 @@
 apply plugin: 'com.android.library'
 
+def DEFAULT_COMPILE_SDK_VERSION = 23
+def DEFAULT_BUILD_TOOLS_VERSION = "23.0.2"
+def DEFAULT_TARGET_SDK_VERSION = 23
+def DEFAULT_SUPPORT_LIB_VERSION = "23.1.0"
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"
     }
@@ -17,8 +22,10 @@ android {
     }
 }
 
+def supportVersion = rootProject.hasProperty('supportLibVersion') ? rootProject.supportLibVersion : DEFAULT_SUPPORT_LIB_VERSION
+
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:23.1.0'
+    compile 'com.android.support:appcompat-v7:${supportVersion}'
     compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Here is a fix for issue #285 

It is now the recommended way for react-native projects to use the root project versions.
And this PR is heavily inspired by how [firebase](https://github.com/invertase/react-native-firebase/commit/eb75f789803848d20427bc0675528fb0eeca0238) did it, so there is a fallback for the old versions too.