### PR TITLE
Update AudioRecorderManager.m to include requiresMainQueueSetup

### DIFF
--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -64,6 +64,10 @@ RCT_EXPORT_MODULE();
   }
 }
 
++ (BOOL)requiresMainQueueSetup{
+  return YES;
+}
+
 - (void)stopProgressTimer {
   [_progressUpdateTimer invalidate];
 }

--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -68,9 +68,6 @@ RCT_EXPORT_MODULE();
   }
 }
 
-+ (BOOL)requiresMainQueueSetup{
-  return YES;
-}
 
 - (void)stopProgressTimer {
   [_progressUpdateTimer invalidate];


### PR DESCRIPTION
This commit handles the yellow warning bubble that pops up at app restart.