### PR TITLE
Deactivating recording session if needed, on app background

### DIFF
--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -12,6 +12,7 @@
 #import <React/RCTUtils.h>
 #import <React/RCTEventDispatcher.h>
 #import <AVFoundation/AVFoundation.h>
+#import <UIKit/UIKit.h>
 
 NSString *const AudioRecorderEventProgress = @"recordingProgress";
 NSString *const AudioRecorderEventFinished = @"recordingFinished";
@@ -39,6 +40,25 @@ NSString *const AudioRecorderEventFinished = @"recordingFinished";
 
 RCT_EXPORT_MODULE();
 
+- (instancetype)init
+  {
+    self = [super init];
+    if (self) {
+      [self registerForNotifications];
+    }
+    return self;
+  }
+  
+- (void)registerForNotifications {
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWillResignActive) name: UIApplicationWillResignActiveNotification object: nil];
+}
+  
+- (void)applicationWillResignActive {
+  if (_audioRecorder && !_audioRecorder.isRecording) {
+    [_recordSession setActive:NO error: nil];
+  }
+}
+  
 + (BOOL)requiresMainQueueSetup {
   return YES;
 }


### PR DESCRIPTION
In our app, we faced an issue where the recording indicator (the red status bar/icon) didnt go away when the app was in the background, even when it was not recording. Making this change fixed it.

Apple in fact recommends that apps that support background audio recording deactivate the recording session when recording is not happening, and they go into the background ([reference](https://developer.apple.com/library/archive/documentation/Audio/Conceptual/AudioSessionProgrammingGuide/ConfiguringanAudioSession/ConfiguringanAudioSession.html#//apple_ref/doc/uid/TP40007875-CH2-SW23)).

> Many apps never need to deactivate their audio session explicitly. Important exceptions include VoIP apps, turn-by-turn navigation apps, and, in some cases, playback and recording apps.

> If an app supports background audio playback or recording, deactivate its audio session when entering the background if the app is not actively using audio (or preparing to use audio). Doing so allows the system to free up audio resources so that they may be used by other processes. It also prevents the app's audio session from being deactivated when the app process is suspended by the operating system (see AVAudioSessionInterruptionWasSuspendedKey).
