### PR TITLE
use double quotes in build.gradle to allow interpolation of supportVersion variable

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,6 @@ def supportVersion = rootProject.hasProperty('supportLibVersion') ? rootProject.
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:${supportVersion}'
+    compile "com.android.support:appcompat-v7:${supportVersion}"
     compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
This fixes #332 